### PR TITLE
Move general createRelationshipFilter from Neo4jUtil to QueryUtils

### DIFF
--- a/dao-api/src/main/java/com/linkedin/metadata/dao/utils/QueryUtils.java
+++ b/dao-api/src/main/java/com/linkedin/metadata/dao/utils/QueryUtils.java
@@ -7,6 +7,9 @@ import com.linkedin.metadata.query.Condition;
 import com.linkedin.metadata.query.Criterion;
 import com.linkedin.metadata.query.CriterionArray;
 import com.linkedin.metadata.query.Filter;
+import com.linkedin.metadata.query.RelationshipDirection;
+import com.linkedin.metadata.query.RelationshipFilter;
+
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -54,6 +57,34 @@ public class QueryUtils {
   @Nonnull
   public static Filter newFilter(@Nonnull String field, @Nonnull String value) {
     return newFilter(Collections.singletonMap(field, value));
+  }
+
+
+  /**
+   * Create {@link RelationshipFilter} using filter and relationship direction.
+   *
+   * @param filter {@link Filter} filter
+   * @param relationshipDirection {@link RelationshipDirection} relationship direction
+   * @return RelationshipFilter
+   */
+  @Nonnull
+  public static RelationshipFilter newRelationshipFilter(@Nonnull Filter filter,
+                                                         @Nonnull RelationshipDirection relationshipDirection) {
+    return new RelationshipFilter().setCriteria(filter.getCriteria()).setDirection(relationshipDirection);
+  }
+
+  /**
+   * Create {@link RelationshipFilter} using filter conditions and relationship direction.
+   *
+   * @param field field to create a filter on
+   * @param value field value to be filtered
+   * @param relationshipDirection {@link RelationshipDirection} relationship direction
+   * @return RelationshipFilter
+   */
+  @Nonnull
+  public static RelationshipFilter newRelationshipFilter(@Nonnull String field, @Nonnull String value,
+                                                         @Nonnull RelationshipDirection relationshipDirection) {
+    return newRelationshipFilter(newFilter(field, value), relationshipDirection);
   }
 
   /**

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/utils/QueryUtilTest.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/utils/QueryUtilTest.java
@@ -5,7 +5,10 @@ import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.aspect.AspectVersion;
 import com.linkedin.metadata.query.Condition;
 import com.linkedin.metadata.query.Criterion;
+import com.linkedin.metadata.query.CriterionArray;
 import com.linkedin.metadata.query.Filter;
+import com.linkedin.metadata.query.RelationshipDirection;
+import com.linkedin.metadata.query.RelationshipFilter;
 import com.linkedin.testing.AspectBar;
 import com.linkedin.testing.AspectFoo;
 import java.util.Collections;
@@ -13,6 +16,7 @@ import java.util.Map;
 import java.util.Set;
 import org.testng.annotations.Test;
 
+import static com.linkedin.metadata.dao.utils.QueryUtils.newRelationshipFilter;
 import static org.testng.Assert.*;
 
 
@@ -37,6 +41,19 @@ public class QueryUtilTest {
     Map<String, String> paramsWithNulls = Collections.singletonMap("foo", null);
     filter = QueryUtils.newFilter(paramsWithNulls);
     assertEquals(filter.getCriteria().size(), 0);
+  }
+
+  @Test
+  public void testCreateRelationshipFilter() {
+    String field = "field";
+    String value = "value";
+    RelationshipDirection direction = RelationshipDirection.OUTGOING;
+
+    RelationshipFilter relationshipFilter = new RelationshipFilter().setCriteria(new CriterionArray(
+                    Collections.singletonList(new Criterion().setField(field).setValue(value).setCondition(Condition.EQUAL))))
+            .setDirection(direction);
+
+    assertEquals(newRelationshipFilter(field, value, direction), relationshipFilter);
   }
 
   @Test

--- a/dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/Neo4jUtil.java
+++ b/dao-impl/neo4j-dao/src/main/java/com/linkedin/metadata/dao/Neo4jUtil.java
@@ -6,8 +6,6 @@ import com.linkedin.metadata.dao.utils.RecordUtils;
 import com.linkedin.metadata.query.Condition;
 import com.linkedin.metadata.query.CriterionArray;
 import com.linkedin.metadata.query.Filter;
-import com.linkedin.metadata.query.RelationshipDirection;
-import com.linkedin.metadata.query.RelationshipFilter;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -20,8 +18,6 @@ import org.apache.commons.lang3.ClassUtils;
 import org.neo4j.driver.types.Node;
 import org.neo4j.driver.types.Path;
 import org.neo4j.driver.types.Relationship;
-
-import static com.linkedin.metadata.dao.utils.QueryUtils.*;
 
 
 public class Neo4jUtil {
@@ -247,32 +243,5 @@ public class Neo4jUtil {
   @Nonnull
   public static String getType(@Nonnull Class<? extends RecordTemplate> recordClass) {
     return new StringBuilder("`").append(recordClass.getCanonicalName()).append("`").toString();
-  }
-
-  /**
-   * Create {@link RelationshipFilter} using filter and relationship direction.
-   *
-   * @param filter {@link Filter} filter
-   * @param relationshipDirection {@link RelationshipDirection} relationship direction
-   * @return RelationshipFilter
-   */
-  @Nonnull
-  public static RelationshipFilter createRelationshipFilter(@Nonnull Filter filter,
-      @Nonnull RelationshipDirection relationshipDirection) {
-    return new RelationshipFilter().setCriteria(filter.getCriteria()).setDirection(relationshipDirection);
-  }
-
-  /**
-   * Create {@link RelationshipFilter} using filter conditions and relationship direction.
-   *
-   * @param field field to create a filter on
-   * @param value field value to be filtered
-   * @param relationshipDirection {@link RelationshipDirection} relationship direction
-   * @return RelationshipFilter
-   */
-  @Nonnull
-  public static RelationshipFilter createRelationshipFilter(@Nonnull String field, @Nonnull String value,
-      @Nonnull RelationshipDirection relationshipDirection) {
-    return createRelationshipFilter(newFilter(field, value), relationshipDirection);
   }
 }

--- a/dao-impl/neo4j-dao/src/test/java/com/linkedin/metadata/dao/Neo4jUtilTest.java
+++ b/dao-impl/neo4j-dao/src/test/java/com/linkedin/metadata/dao/Neo4jUtilTest.java
@@ -179,19 +179,6 @@ public class Neo4jUtilTest {
   }
 
   @Test
-  public void testCreateRelationshipFilter() {
-    String field = "field";
-    String value = "value";
-    RelationshipDirection direction = RelationshipDirection.OUTGOING;
-
-    RelationshipFilter relationshipFilter = new RelationshipFilter().setCriteria(new CriterionArray(
-        Collections.singletonList(new Criterion().setField(field).setValue(value).setCondition(Condition.EQUAL))))
-        .setDirection(direction);
-
-    assertEquals(createRelationshipFilter(field, value, direction), relationshipFilter);
-  }
-
-  @Test
   public void testPathSegmentToRecordList() {
     FooUrn fooUrn = makeFooUrn(1);
     Node fooNode = new InternalNode(0, Collections.singletonList("com.linkedin.testing.EntityFoo"),


### PR DESCRIPTION
These methods are not Neo4j-specific so they can be moved out of Neo4Util. This removes Neo4jUtil imports from classes, that have no other reference to neo4j.