### PR TITLE
Add base query dao test

### DIFF
--- a/dao-api/build.gradle
+++ b/dao-api/build.gradle
@@ -1,3 +1,5 @@
+apply plugin: 'java'
+apply plugin: 'java-test-fixtures'
 apply plugin: 'pegasus'
 
 apply from: "$rootDir/gradle/java-publishing.gradle"

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/BaseQueryDAOTestBase.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/BaseQueryDAOTestBase.java
@@ -1,0 +1,464 @@
+package com.linkedin.metadata.dao;
+
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.dao.internal.BaseGraphWriterDAO;
+import com.linkedin.metadata.dao.utils.Statement;
+import com.linkedin.metadata.query.Filter;
+import com.linkedin.metadata.query.RelationshipDirection;
+import com.linkedin.testing.EntityBar;
+import com.linkedin.testing.EntityBaz;
+import com.linkedin.testing.EntityFoo;
+import com.linkedin.testing.RelationshipBar;
+import com.linkedin.testing.RelationshipFoo;
+import com.linkedin.testing.urn.BarUrn;
+import com.linkedin.testing.urn.BazUrn;
+import com.linkedin.testing.urn.FooUrn;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.javatuples.Triplet;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.annotation.Nonnull;
+
+import static com.linkedin.metadata.dao.utils.QueryUtils.*;
+import static com.linkedin.testing.TestUtils.*;
+import static org.testng.Assert.*;
+
+
+abstract public class BaseQueryDAOTestBase<Q extends BaseQueryDAO, W extends BaseGraphWriterDAO> {
+
+  protected Q _dao;
+  protected W _writer;
+
+  abstract @Nonnull Q newBaseQueryDao();
+  abstract @Nonnull W newBaseGraphWriterDao();
+
+  @BeforeMethod
+  public void init() {
+    _dao = newBaseQueryDao();
+    _writer = newBaseGraphWriterDao();
+  }
+
+  @Test
+  public void testFindEntityByUrn() throws Exception {
+    FooUrn urn = makeFooUrn(1);
+    EntityFoo entity = new EntityFoo().setUrn(urn).setValue("foo");
+
+    _writer.addEntity(entity);
+
+    Filter filter = newFilter("urn", urn.toString());
+    List<EntityFoo> found = _dao.findEntities(EntityFoo.class, filter, -1, -1);
+
+    assertEquals(found.size(), 1);
+    assertEquals(found.get(0), entity);
+  }
+
+  @Test
+  public void testFindEntityByAttribute() throws Exception {
+    FooUrn urn1 = makeFooUrn(1);
+    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo");
+    _writer.addEntity(entity1);
+
+    FooUrn urn2 = makeFooUrn(2);
+    EntityFoo entity2 = new EntityFoo().setUrn(urn2).setValue("foo");
+    _writer.addEntity(entity2);
+
+    // find by removed
+    Filter filter1 = newFilter("value", "foo");
+    List<EntityFoo> found = _dao.findEntities(EntityFoo.class, filter1, -1, -1);
+    assertEquals(found, Arrays.asList(entity1, entity2));
+
+    // find with limit
+    found = _dao.findEntities(EntityFoo.class, filter1, -1, 1);
+    assertEquals(found, Collections.singletonList(entity1));
+
+    // find with offset
+    found = _dao.findEntities(EntityFoo.class, filter1, 1, -1);
+    assertEquals(found, Collections.singletonList(entity2));
+  }
+
+  @Test
+  public void testFindEntityByQuery() throws Exception {
+    FooUrn urn1 = makeFooUrn(1);
+    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo");
+    _writer.addEntity(entity1);
+
+    Statement statement = new Statement("MATCH (n {value:\"foo\"}) RETURN n ORDER BY n.urn", Collections.emptyMap());
+    List<EntityFoo> found = _dao.findEntities(EntityFoo.class, statement);
+    assertEquals(found.size(), 1);
+    assertEquals(found.get(0), entity1);
+
+    FooUrn urn2 = makeFooUrn(2);
+    EntityFoo entity2 = new EntityFoo().setUrn(urn2).setValue("foo");
+    _writer.addEntity(entity2);
+
+    found = _dao.findEntities(EntityFoo.class, statement);
+    assertEquals(found.size(), 2);
+    assertEquals(found.get(0), entity1);
+    assertEquals(found.get(1), entity2);
+  }
+
+  @Test
+  public void testFindEntityWithOneRelationship() throws Exception {
+    // Test interface 1 & 3
+    FooUrn urn1 = makeFooUrn(1);
+    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo1");
+    _writer.addEntity(entity1);
+
+    FooUrn urn2 = makeFooUrn(2);
+    EntityFoo entity2 = new EntityFoo().setUrn(urn2).setValue("foo2");
+    _writer.addEntity(entity2);
+
+    FooUrn urn3 = makeFooUrn(3);
+    EntityFoo entity3 = new EntityFoo().setUrn(urn3).setValue("foo3");
+    _writer.addEntity(entity3);
+
+    BarUrn urn4 = makeBarUrn(4);
+    EntityBar entity4 = new EntityBar().setUrn(urn4).setValue("bar4");
+    _writer.addEntity(entity4);
+
+    BarUrn urn5 = makeBarUrn(5);
+    EntityBar entity5 = new EntityBar().setUrn(urn5).setValue("bar5");
+    _writer.addEntity(entity5);
+
+    // create relationship urn1 -(r:Foo)-> urn2 -(r:Foo)-> urn3 (example use case: ReportTo list)
+    // also relationship urn1 -(r:Foo)-> urn4, and urn1 -(r:Bar)-> urn5
+    RelationshipFoo relationshipFoo1To2 = new RelationshipFoo().setSource(urn1).setDestination(urn2);
+    _writer.addRelationship(relationshipFoo1To2);
+
+    RelationshipFoo relationshipFoo2o3 = new RelationshipFoo().setSource(urn2).setDestination(urn3).setType("apa");
+    _writer.addRelationship(relationshipFoo2o3);
+
+    RelationshipFoo relationshipFoo1o4 = new RelationshipFoo().setSource(urn1).setDestination(urn4);
+    _writer.addRelationship(relationshipFoo1o4);
+
+    RelationshipBar relationshipBar1o5 = new RelationshipBar().setSource(urn1).setDestination(urn5);
+    _writer.addRelationship(relationshipBar1o5);
+
+    // test source filter with urn
+    Filter sourceFilter = newFilter("urn", urn2.toString());
+
+    // use case: the direct reportee to me (urn2)
+    List<RecordTemplate> resultIncoming =
+        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING), 0, 10);
+    assertEquals(resultIncoming.size(), 1);
+    assertEquals(resultIncoming.get(0), entity1);
+
+    // use case: the manager I (urn2) am report to
+    List<RecordTemplate> resultOutgoing =
+        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 0, 10);
+    assertEquals(resultOutgoing.size(), 1);
+    assertEquals(resultOutgoing.get(0), entity3);
+
+    // use case: give me my friends at one degree/hop
+    List<RecordTemplate> resultUndirected =
+        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.UNDIRECTED), 0, 10);
+    assertEquals(resultUndirected.size(), 2);
+    assertEquals(resultUndirected.get(0), entity1);
+    assertEquals(resultUndirected.get(1), entity3);
+
+    // Test: if dest entity type is not specified, from urn1, it will return a mixed collection of entities like urn2 and urn4
+    // urn5 should not be returned because it is based on RelationshipBar.
+    sourceFilter = newFilter("urn", urn1.toString());
+    List<RecordTemplate> resultNullDest =
+        _dao.findEntities(EntityFoo.class, sourceFilter, null, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 0, 10);
+    assertEquals(resultNullDest.size(), 2);
+    assertEquals(resultNullDest.get(0), entity2);
+    assertEquals(resultNullDest.get(1), entity4);
+
+    // Test: source filter on other attributes
+    sourceFilter = newFilter("value", "foo2");
+    List<RecordTemplate> result =
+        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING), 0, 10);
+    assertEquals(result, resultIncoming);
+
+    //Test relationship filters on the attributes
+    Filter filter = newFilter("type", "apa");
+    List<RecordTemplate> resultWithRelationshipFilter =
+        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(filter, RelationshipDirection.OUTGOING), 0, 10);
+    assertEquals(resultWithRelationshipFilter.size(), 1);
+    assertEquals(resultWithRelationshipFilter.get(0), entity3);
+
+    //Test a wrong value for relationship filters
+    Filter relationshipFilterWrongValue = newFilter("type", "wrongValue");
+    List<RecordTemplate> resultWithRelationshipFilter2 =
+        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(relationshipFilterWrongValue, RelationshipDirection.OUTGOING), 0, 10);
+    assertEquals(resultWithRelationshipFilter2.size(), 0);
+  }
+
+  @Test
+  public void testFindEntitiesMultiHops() throws Exception {
+    // Test interface 5
+    FooUrn urn1 = makeFooUrn(1);
+    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo1");
+    _writer.addEntity(entity1);
+
+    FooUrn urn2 = makeFooUrn(2);
+    EntityFoo entity2 = new EntityFoo().setUrn(urn2).setValue("foo2");
+    _writer.addEntity(entity2);
+
+    FooUrn urn3 = makeFooUrn(3);
+    EntityFoo entity3 = new EntityFoo().setUrn(urn3).setValue("foo3");
+    _writer.addEntity(entity3);
+
+    // create relationship urn1 -> urn2 -> urn3 (use case: ReportTo list)
+    RelationshipFoo relationshipFoo1To2 = new RelationshipFoo().setSource(urn1).setDestination(urn2);
+    _writer.addRelationship(relationshipFoo1To2);
+
+    RelationshipFoo relationshipFoo2o3 = new RelationshipFoo().setSource(urn2).setDestination(urn3);
+    _writer.addRelationship(relationshipFoo2o3);
+
+    // From urn1, get result with one hop, such as direct manager
+    Filter sourceFilter = newFilter("urn", urn1.toString());
+    List<RecordTemplate> result =
+        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 1, 1, 0, 10);
+    assertEquals(result.size(), 1);
+    assertEquals(result.get(0), entity2);
+
+    // get result with 2 hops, two managers
+    List<RecordTemplate> result2 =
+        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 1, 2, 0, 10);
+    assertEquals(result2.size(), 2);
+    assertEquals(result2.get(0), entity2);
+    assertEquals(result2.get(1), entity3);
+
+    // get result with >= 3 hops, until end of the chain
+    List<RecordTemplate> result3 =
+        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 1, 3, 0, 10);
+    assertEquals(result3.size(), 2);
+    assertEquals(result3.get(0), entity2);
+    assertEquals(result3.get(1), entity3);
+
+    // test dest filter, filter the list of result and only get urn3 back
+    Filter destFilter = newFilter("urn", urn3.toString());
+    List<RecordTemplate> result4 =
+        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, destFilter, RelationshipFoo.class,
+            newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 1, 3, 0, 10);
+    assertEquals(result4.size(), 1);
+    assertEquals(result4.get(0), entity3);
+
+    // test relationship filter: TODO: for all the interfaces add relationship filter testing
+
+    // corner cases 1: minHops set to 3, get no result because the relationship chain reaches the end
+    List<RecordTemplate> result5 =
+        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 3, 6, 0, 10);
+    assertEquals(result5.size(), 0);
+
+    // corner cases 2: minHops < maxHops, return no result
+    List<RecordTemplate> result6 =
+        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 6, 0, 0, 10);
+    assertEquals(result6.size(), 0);
+
+    // test the relationship directions
+    // From urn2, get result with one hop, such as direct manager.
+    // NOTE: without direction specified in the matchTemplate, urn1 could end up in the result too
+    Filter sourceFilter2 = newFilter("urn", urn2.toString());
+    List<RecordTemplate> result21 =
+        _dao.findEntities(EntityFoo.class, sourceFilter2, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 1, 1, 0, 10);
+    assertEquals(result21.size(), 1);
+    assertEquals(result21.get(0), entity3);
+
+    // get result with 2 hops, 1 manager
+    List<RecordTemplate> result22 =
+        _dao.findEntities(EntityFoo.class, sourceFilter2, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 1, 2, 0, 10);
+    assertEquals(result22.size(), 1);
+    assertEquals(result22.get(0), entity3);
+
+    // let's see what we get if we use interface 1, it should return urn3 only
+    List<RecordTemplate> resultInterface1 =
+        _dao.findEntities(EntityFoo.class, sourceFilter2, null, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 0, 10);
+    assertEquals(resultInterface1.size(), 1);
+    assertEquals(resultInterface1.get(0), entity3);
+
+    // test INCOMING direction, use case such as who report to URN3
+    Filter sourceFilter3 = newFilter("urn", urn3.toString());
+    List<RecordTemplate> resultIncoming =
+        _dao.findEntities(EntityFoo.class, sourceFilter3, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
+            newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING), 1, 2, 0, 10);
+    assertEquals(resultIncoming.size(), 2);
+    assertEquals(resultIncoming.get(0), entity2);
+    assertEquals(resultIncoming.get(1), entity1);
+  }
+
+  @Test
+  public void testFindEntitiesViaTraversePathes() throws Exception {
+    // Test interface 4
+    FooUrn urn1 = makeFooUrn(1);
+    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("CorpGroup1");
+    _writer.addEntity(entity1);
+
+    BarUrn urn2 = makeBarUrn(2);
+    EntityBar entity2 = new EntityBar().setUrn(urn2).setValue("CorpUser2");
+    _writer.addEntity(entity2);
+
+    BazUrn urn3 = makeBazUrn(3);
+    EntityBaz entity3 = new EntityBaz().setUrn(urn3).setValue("Dataset3");
+    _writer.addEntity(entity3);
+
+    // create relationship urn1 -> urn2 with RelationshipFoo (ex: CorpGroup1 HasMember CorpUser2)
+    RelationshipFoo relationshipFoo1To2 = new RelationshipFoo().setSource(urn1).setDestination(urn2);
+    _writer.addRelationship(relationshipFoo1To2);
+
+    // create relationship urn2 -> urn3 with RelationshipBar (ex: Dataset3 is OwnedBy CorpUser2)
+    RelationshipBar relationshipFoo2o3 = new RelationshipBar().setSource(urn3).setDestination(urn2);
+    _writer.addRelationship(relationshipFoo2o3);
+
+    // test source filter with urn
+    Filter sourceFilter = newFilter("urn", urn1.toString());
+
+    // use case: return all the datasets owned by corpgroup1
+    List paths = new ArrayList();
+    paths.add(
+        Triplet.with(RelationshipFoo.class, newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING),
+            EntityBar.class));
+    paths.add(
+        Triplet.with(RelationshipBar.class, newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING),
+            EntityBaz.class));
+    List<RecordTemplate> result = _dao.findEntities(EntityFoo.class, sourceFilter, paths, 0, 10);
+    assertEquals(result.size(), 1);
+    assertEquals(result.get(0), entity3);
+
+    // use case: return all the datasets owned by corpgroup1
+    List paths2 = new ArrayList();
+    paths2.add(
+        Triplet.with(RelationshipFoo.class, newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.UNDIRECTED),
+            EntityBar.class));
+    paths2.add(
+        Triplet.with(RelationshipBar.class, newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.UNDIRECTED),
+            EntityBaz.class));
+    List<RecordTemplate> result2 = _dao.findEntities(EntityFoo.class, sourceFilter, paths2, 0, 10);
+    assertEquals(result2, result);
+
+    // add another user & dataset
+    BarUrn urn4 = makeBarUrn(4);
+    EntityBar entity4 = new EntityBar().setUrn(urn4).setValue("CorpUser4");
+    _writer.addEntity(entity4);
+
+    BazUrn urn5 = makeBazUrn(5);
+    EntityBaz entity5 = new EntityBaz().setUrn(urn5).setValue("Dataset5");
+    _writer.addEntity(entity5);
+
+    // create relationship urn4 -> urn5 with RelationshipBar
+    RelationshipBar relationshipFoo4o5 = new RelationshipBar().setSource(urn5).setDestination(urn4);
+    _writer.addRelationship(relationshipFoo4o5);
+
+    // create relationship urn1 -> urn4 with RelationshipFoo
+    RelationshipFoo relationshipFoo1To4 = new RelationshipFoo().setSource(urn1).setDestination(urn4);
+    _writer.addRelationship(relationshipFoo1To4);
+
+    List paths3 = new ArrayList();
+    paths3.add(
+        Triplet.with(RelationshipFoo.class, newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING),
+            EntityBar.class));
+    paths3.add(
+        Triplet.with(RelationshipBar.class, newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING),
+            EntityBaz.class));
+    List<RecordTemplate> result3 = _dao.findEntities(EntityFoo.class, sourceFilter, paths3, 0, 10);
+    assertEquals(result3.size(), 2);
+    assertEquals(result3.get(0), entity5);
+    assertEquals(result3.get(1), entity3);
+
+    // test nulls
+    List paths4 = new ArrayList();
+    paths4.add(Triplet.with(null, null, null));
+    List<RecordTemplate> result4 = _dao.findEntities(EntityFoo.class, sourceFilter, paths4, 0, 10);
+    assertEquals(result4.size(), 2);
+    assertEquals(result4.get(0), entity4);
+    assertEquals(result4.get(1), entity2);
+
+    // test partial nulls with entity
+    List paths5 = new ArrayList();
+    paths5.add(
+        Triplet.with(null, newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), EntityBar.class));
+    List<RecordTemplate> result5 = _dao.findEntities(EntityFoo.class, sourceFilter, paths5, 0, 10);
+    assertEquals(result5.size(), 2);
+    assertEquals(result5.get(0), entity4);
+    assertEquals(result5.get(1), entity2);
+
+    // test partial nulls with relationship
+    List paths6 = new ArrayList();
+    paths6.add(Triplet.with(null, null, EntityBar.class));
+    List<RecordTemplate> result6 = _dao.findEntities(EntityFoo.class, sourceFilter, paths6, 0, 10);
+    assertEquals(result6.size(), 2);
+    assertEquals(result6.get(0), entity4);
+    assertEquals(result6.get(1), entity2);
+  }
+
+  @Test
+  public void testFindRelationship() throws Exception {
+    FooUrn urn1 = makeFooUrn(1);
+    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo");
+    _writer.addEntity(entity1);
+
+    BarUrn urn2 = makeBarUrn(2);
+    EntityBar entity2 = new EntityBar().setUrn(urn2).setValue("bar");
+    _writer.addEntity(entity2);
+
+    // create relationship urn1 -> urn2
+    RelationshipFoo relationship = new RelationshipFoo().setSource(urn1).setDestination(urn2);
+    _writer.addRelationship(relationship);
+
+    // find by source
+    Filter filter1 = newFilter("urn", urn1.toString());
+    List<RelationshipFoo> found =
+        _dao.findRelationshipsFromSource(null, filter1, RelationshipFoo.class, EMPTY_FILTER, -1, -1);
+    assertEquals(found, Collections.singletonList(relationship));
+
+    // find by destination
+    Filter filter2 = newFilter("urn", urn2.toString());
+    found =
+        _dao.findRelationshipsFromDestination(EntityBar.class, filter2, RelationshipFoo.class, EMPTY_FILTER, -1, -1);
+    assertEquals(found, Collections.singletonList(relationship));
+
+    // find by source and destination
+    found = _dao.findRelationships(null, filter1, null, filter2, RelationshipFoo.class, EMPTY_FILTER, 0, 10);
+    assertEquals(found, Collections.singletonList(relationship));
+  }
+
+  @Test
+  public void testFindRelationshipByQuery() throws Exception {
+    FooUrn urn1 = makeFooUrn(1);
+    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo");
+    _writer.addEntity(entity1);
+
+    BarUrn urn2 = makeBarUrn(2);
+    EntityBar entity2 = new EntityBar().setUrn(urn2).setValue("bar");
+    _writer.addEntity(entity2);
+
+    RelationshipFoo relationship = new RelationshipFoo().setSource(urn1).setDestination(urn2);
+    _writer.addRelationship(relationship);
+
+    // with type
+    Map<String, Object> params = new HashMap<>();
+    params.put("src", urn1.toString());
+    Statement statement1 = new Statement("MATCH (src {urn:$src})-[r]->(dest) RETURN src, r, dest", params);
+    List<RelationshipFoo> found = _dao.findRelationships(RelationshipFoo.class, statement1);
+    assertEquals(found, Collections.singletonList(relationship));
+
+    // without type
+    params.put("dest", urn2.toString());
+    Statement statement2 = new Statement("MATCH (src {urn:$src})-[r]->(dest {urn:$dest}) RETURN src, r, dest", params);
+    List<RecordTemplate> foundNoType = _dao.findMixedTypesRelationships(statement2);
+    assertEquals(foundNoType, Collections.singletonList(relationship));
+  }
+}

--- a/dao-api/src/test/java/com/linkedin/metadata/dao/internal/BaseGraphWriterDAOTestBase.java
+++ b/dao-api/src/test/java/com/linkedin/metadata/dao/internal/BaseGraphWriterDAOTestBase.java
@@ -1,0 +1,379 @@
+package com.linkedin.metadata.dao.internal;
+
+import com.linkedin.common.urn.Urn;
+import com.linkedin.data.template.RecordTemplate;
+import com.linkedin.metadata.dao.BaseQueryDAO;
+import com.linkedin.metadata.query.Criterion;
+import com.linkedin.metadata.query.CriterionArray;
+import com.linkedin.metadata.query.Filter;
+import com.linkedin.testing.EntityBar;
+import com.linkedin.testing.EntityFoo;
+import com.linkedin.testing.RelationshipFoo;
+import com.linkedin.testing.urn.BarUrn;
+import com.linkedin.testing.urn.FooUrn;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.annotation.Nonnull;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static com.linkedin.metadata.dao.internal.BaseGraphWriterDAO.RemovalOption.*;
+import static com.linkedin.testing.TestUtils.*;
+import static org.testng.Assert.*;
+
+
+abstract public class BaseGraphWriterDAOTestBase<W extends BaseGraphWriterDAO, Q extends BaseQueryDAO> {
+
+  private W _dao;
+  private Q _reader;
+
+  abstract @Nonnull W newBaseGraphWriterDao();
+  abstract @Nonnull Q newBaseQueryDao();
+
+  @Nonnull
+  abstract public Optional<Map<String, Object>> getNode(@Nonnull Urn urn);
+
+  @Nonnull
+  abstract public List<Map<String, Object>> getAllNodes(@Nonnull Urn urn);
+
+  @Nonnull
+  abstract public List<Map<String, Object>> getEdges(@Nonnull RecordTemplate relationship);
+
+  @Nonnull
+  abstract public List<Map<String, Object>> getEdgesFromSource(
+          @Nonnull Urn sourceUrn,
+          @Nonnull Class<? extends RecordTemplate> relationshipClass
+  );
+
+  @BeforeMethod
+  public void init() {
+    _dao = newBaseGraphWriterDao();
+    _reader = newBaseQueryDao();
+  }
+
+  @Test
+  public void testAddEntity() throws Exception {
+    FooUrn urn = makeFooUrn(1);
+    EntityFoo entity = new EntityFoo().setUrn(urn).setValue("foo");
+
+    _dao.addEntity(entity);
+    Optional<Map<String, Object>> node = getNode(urn);
+    assertEntityFoo(node.get(), entity);
+  }
+
+  @Test
+  public void testRemoveEntity() throws Exception {
+    FooUrn urn = makeFooUrn(1);
+    EntityFoo entity = new EntityFoo().setUrn(urn).setValue("foo");
+
+    // addEntity tested in testAddEntity
+    _dao.addEntity(entity);
+
+    _dao.removeEntity(urn);
+    Optional<Map<String, Object>> node = getNode(urn);
+    assertFalse(node.isPresent());
+  }
+
+  @Test
+  public void testPartialUpdateEntity() throws Exception {
+    FooUrn urn = makeFooUrn(1);
+    EntityFoo entity = new EntityFoo().setUrn(urn);
+
+    _dao.addEntity(entity);
+    Optional<Map<String, Object>> node = getNode(urn);
+    assertEntityFoo(node.get(), entity);
+
+    // add value for optional field
+    EntityFoo entity2 = new EntityFoo().setUrn(urn).setValue("IamTheSameEntity");
+    _dao.addEntity(entity2);
+    node = getNode(urn);
+    assertEquals(getAllNodes(urn).size(), 1);
+    assertEntityFoo(node.get(), entity2);
+
+    // change value for optional field
+    EntityFoo entity3 = new EntityFoo().setUrn(urn).setValue("ChangeValue");
+    _dao.addEntity(entity3);
+    node = getNode(urn);
+    assertEquals(getAllNodes(urn).size(), 1);
+    assertEntityFoo(node.get(), entity3);
+  }
+
+  @Test
+  public void testAddEntities() throws Exception {
+    EntityFoo entity1 = new EntityFoo().setUrn(makeFooUrn(1)).setValue("foo");
+    EntityFoo entity2 = new EntityFoo().setUrn(makeFooUrn(2)).setValue("bar");
+    EntityFoo entity3 = new EntityFoo().setUrn(makeFooUrn(3)).setValue("baz");
+    List<EntityFoo> entities = Arrays.asList(entity1, entity2, entity3);
+
+    _dao.addEntities(entities);
+    assertEntityFoo(getNode(entity1.getUrn()).get(), entity1);
+    assertEntityFoo(getNode(entity2.getUrn()).get(), entity2);
+    assertEntityFoo(getNode(entity3.getUrn()).get(), entity3);
+  }
+
+  @Test
+  public void testRemoveEntities() throws Exception {
+    EntityFoo entity1 = new EntityFoo().setUrn(makeFooUrn(1)).setValue("foo");
+    EntityFoo entity2 = new EntityFoo().setUrn(makeFooUrn(2)).setValue("bar");
+    EntityFoo entity3 = new EntityFoo().setUrn(makeFooUrn(3)).setValue("baz");
+    List<EntityFoo> entities = Arrays.asList(entity1, entity2, entity3);
+
+    // addEntities tested in testAddEntities
+    _dao.addEntities(entities);
+
+    _dao.removeEntities(Arrays.asList(entity1.getUrn(), entity3.getUrn()));
+    assertFalse(getNode(entity1.getUrn()).isPresent());
+    assertTrue(getNode(entity2.getUrn()).isPresent());
+    assertFalse(getNode(entity3.getUrn()).isPresent());
+  }
+
+  @Test
+  public void testAddRelationshipNodeNonExist() throws Exception {
+    FooUrn urn1 = makeFooUrn(1);
+    BarUrn urn2 = makeBarUrn(2);
+    RelationshipFoo relationship = new RelationshipFoo().setSource(urn1).setDestination(urn2);
+
+    _dao.addRelationship(relationship, REMOVE_NONE);
+
+    assertRelationshipFoo(getEdges(relationship), 1);
+    assertEntityFoo(getNode(urn1).get(), new EntityFoo().setUrn(urn1));
+    assertEntityBar(getNode(urn2).get(), new EntityBar().setUrn(urn2));
+  }
+
+  @Test
+  public void testPartialUpdateEntityCreatedByRelationship() throws Exception {
+    FooUrn urn1 = makeFooUrn(1);
+    FooUrn urn2 = makeFooUrn(2);
+    RelationshipFoo relationship = new RelationshipFoo().setSource(urn1).setDestination(urn2);
+
+    _dao.addRelationship(relationship, REMOVE_NONE);
+
+    // Check if adding an entity with same urn and with label creates a new node
+    _dao.addEntity(new EntityFoo().setUrn(urn1));
+    assertEquals(getAllNodes(urn1).size(), 1);
+  }
+
+  @Test
+  public void testAddRemoveRelationships() throws Exception {
+    // Add entity1
+    FooUrn urn1 = makeFooUrn(1);
+    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo");
+    _dao.addEntity(entity1);
+    assertEntityFoo(getNode(urn1).get(), entity1);
+
+    // Add entity2
+    BarUrn urn2 = makeBarUrn(2);
+    EntityBar entity2 = new EntityBar().setUrn(urn2).setValue("bar");
+    _dao.addEntity(entity2);
+    assertEntityBar(getNode(urn2).get(), entity2);
+
+    // add relationship1 (urn1 -> urn2)
+    RelationshipFoo relationship1 = new RelationshipFoo().setSource(urn1).setDestination(urn2);
+    _dao.addRelationship(relationship1, REMOVE_NONE);
+    assertRelationshipFoo(getEdges(relationship1), 1);
+
+    // add relationship1 again
+    _dao.addRelationship(relationship1);
+    assertRelationshipFoo(getEdges(relationship1), 1);
+
+    // add relationship2 (urn1 -> urn3)
+    Urn urn3 = makeUrn(3);
+    RelationshipFoo relationship2 = new RelationshipFoo().setSource(urn1).setDestination(urn3);
+    _dao.addRelationship(relationship2);
+    assertRelationshipFoo(getEdgesFromSource(urn1, RelationshipFoo.class), 2);
+
+    // remove relationship1
+    _dao.removeRelationship(relationship1);
+    assertRelationshipFoo(getEdges(relationship1), 0);
+
+    // remove relationship1 & relationship2
+    _dao.removeRelationships(Arrays.asList(relationship1, relationship2));
+    assertRelationshipFoo(getEdgesFromSource(urn1, RelationshipFoo.class), 0);
+  }
+
+  @Test
+  public void testAddRelationshipRemoveAll() throws Exception {
+    // Add entity1
+    FooUrn urn1 = makeFooUrn(1);
+    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo");
+    _dao.addEntity(entity1);
+    assertEntityFoo(getNode(urn1).get(), entity1);
+
+    // Add entity2
+    BarUrn urn2 = makeBarUrn(2);
+    EntityBar entity2 = new EntityBar().setUrn(urn2).setValue("bar");
+    _dao.addEntity(entity2);
+    assertEntityBar(getNode(urn2).get(), entity2);
+
+    // add relationship1 (urn1 -> urn2)
+    RelationshipFoo relationship1 = new RelationshipFoo().setSource(urn1).setDestination(urn2);
+    _dao.addRelationship(relationship1, REMOVE_NONE);
+    assertRelationshipFoo(getEdges(relationship1), 1);
+
+    // add relationship2 (urn1 -> urn3), removeAll from source
+    Urn urn3 = makeUrn(3);
+    RelationshipFoo relationship2 = new RelationshipFoo().setSource(urn1).setDestination(urn3);
+    _dao.addRelationship(relationship2, REMOVE_ALL_EDGES_FROM_SOURCE);
+    assertRelationshipFoo(getEdgesFromSource(urn1, RelationshipFoo.class), 1);
+
+    // add relationship3 (urn4 -> urn3), removeAll from destination
+    Urn urn4 = makeUrn(4);
+    RelationshipFoo relationship3 = new RelationshipFoo().setSource(urn4).setDestination(urn3);
+    _dao.addRelationship(relationship3, REMOVE_ALL_EDGES_TO_DESTINATION);
+    assertRelationshipFoo(getEdgesFromSource(urn1, RelationshipFoo.class), 0);
+    assertRelationshipFoo(getEdgesFromSource(urn4, RelationshipFoo.class), 1);
+
+    // add relationship3 again without removal
+    _dao.addRelationship(relationship3);
+    assertRelationshipFoo(getEdgesFromSource(urn4, RelationshipFoo.class), 1);
+
+    // add relationship3 again, removeAll from source & destination
+    _dao.addRelationship(relationship3, REMOVE_ALL_EDGES_FROM_SOURCE_TO_DESTINATION);
+    assertRelationshipFoo(getEdgesFromSource(urn1, RelationshipFoo.class), 0);
+    assertRelationshipFoo(getEdgesFromSource(urn4, RelationshipFoo.class), 1);
+  }
+
+  @Test
+  public void upsertNodeAddNewProperty() throws Exception {
+    // given
+    final FooUrn urn = makeFooUrn(1);
+    final EntityFoo initialEntity = new EntityFoo().setUrn(urn);
+    final EntityFoo updatedEntity = new EntityFoo().setUrn(urn).setValue("updated");
+
+    // when
+    _dao.addEntity(initialEntity);
+    _dao.addEntity(updatedEntity);
+
+    // then
+    assertEntityFoo(getNode(urn).get(), updatedEntity);
+  }
+
+  @Test
+  public void upsertEdgeAddNewProperty() throws Exception {
+    // given
+    final EntityFoo foo = new EntityFoo().setUrn(makeFooUrn(1));
+    final EntityBar bar = new EntityBar().setUrn(makeBarUrn(2)).setValue("bar");
+    _dao.addEntity(foo);
+    _dao.addEntity(bar);
+
+    final RelationshipFoo initialRelationship =
+        new RelationshipFoo().setSource(foo.getUrn()).setDestination(bar.getUrn());
+    final RelationshipFoo updatedRelationship =
+        new RelationshipFoo().setSource(foo.getUrn()).setDestination(bar.getUrn()).setType("test");
+    _dao.addRelationship(initialRelationship);
+
+    // when
+    _dao.addRelationship(updatedRelationship);
+
+    // then
+    assertEquals(_reader.findRelationships(EntityFoo.class,
+        new Filter().setCriteria(new CriterionArray(new Criterion().setField("urn").setValue(foo.getUrn().toString()))),
+        EntityBar.class,
+        new Filter().setCriteria(new CriterionArray(new Criterion().setField("urn").setValue(bar.getUrn().toString()))),
+        RelationshipFoo.class, new Filter().setCriteria(new CriterionArray()), 0, 10),
+        Collections.singletonList(updatedRelationship));
+  }
+
+  @Test
+  public void upsertNodeChangeProperty() throws Exception {
+    // given
+    final FooUrn urn = makeFooUrn(1);
+    final EntityFoo initialEntity = new EntityFoo().setUrn(urn).setValue("before");
+    final EntityFoo updatedEntity = new EntityFoo().setUrn(urn).setValue("after");
+    _dao.addEntity(initialEntity);
+
+    // when
+    _dao.addEntity(updatedEntity);
+
+    // then
+    assertEntityFoo(getNode(urn).get(), updatedEntity);
+  }
+
+  @Test
+  public void upsertEdgeChangeProperty() throws Exception {
+    // given
+    final EntityFoo foo = new EntityFoo().setUrn(makeFooUrn(1));
+    final EntityBar bar = new EntityBar().setUrn(makeBarUrn(2)).setValue("bar");
+    _dao.addEntity(foo);
+    _dao.addEntity(bar);
+
+    final RelationshipFoo initialRelationship =
+        new RelationshipFoo().setSource(foo.getUrn()).setDestination(bar.getUrn()).setType("before");
+    final RelationshipFoo updatedRelationship =
+        new RelationshipFoo().setSource(foo.getUrn()).setDestination(bar.getUrn()).setType("after");
+    _dao.addRelationship(initialRelationship);
+
+    // when
+    _dao.addRelationship(updatedRelationship);
+
+    // then
+    assertEquals(_reader.findRelationships(EntityFoo.class,
+        new Filter().setCriteria(new CriterionArray(new Criterion().setField("urn").setValue(foo.getUrn().toString()))),
+        EntityBar.class,
+        new Filter().setCriteria(new CriterionArray(new Criterion().setField("urn").setValue(bar.getUrn().toString()))),
+        RelationshipFoo.class, new Filter().setCriteria(new CriterionArray()), 0, 10),
+        Collections.singletonList(updatedRelationship));
+  }
+
+  @Test
+  public void upsertNodeRemovedProperty() throws Exception {
+    // given
+    final FooUrn urn = makeFooUrn(1);
+    final EntityFoo initialEntity = new EntityFoo().setUrn(urn).setValue("before");
+    final EntityFoo updatedEntity = new EntityFoo().setUrn(urn);
+    _dao.addEntity(initialEntity);
+
+    // when
+    _dao.addEntity(updatedEntity);
+
+    // then
+    // Upsert won't ever delete properties.
+    assertEntityFoo(getNode(urn).get(), initialEntity);
+  }
+
+  @Test
+  public void upsertEdgeRemoveProperty() throws Exception {
+    // given
+    final EntityFoo foo = new EntityFoo().setUrn(makeFooUrn(1));
+    final EntityBar bar = new EntityBar().setUrn(makeBarUrn(2)).setValue("bar");
+    _dao.addEntity(foo);
+    _dao.addEntity(bar);
+
+    final RelationshipFoo initialRelationship =
+        new RelationshipFoo().setSource(foo.getUrn()).setDestination(bar.getUrn()).setType("before");
+    final RelationshipFoo updatedRelationship =
+        new RelationshipFoo().setSource(foo.getUrn()).setDestination(bar.getUrn());
+    _dao.addRelationship(initialRelationship);
+
+    // when
+    _dao.addRelationship(updatedRelationship);
+
+    // then
+    assertEquals(_reader.findRelationships(EntityFoo.class,
+        new Filter().setCriteria(new CriterionArray(new Criterion().setField("urn").setValue(foo.getUrn().toString()))),
+        EntityBar.class,
+        new Filter().setCriteria(new CriterionArray(new Criterion().setField("urn").setValue(bar.getUrn().toString()))),
+        RelationshipFoo.class, new Filter().setCriteria(new CriterionArray()), 0, 10),
+        // Upsert won't ever delete properties.
+        Collections.singletonList(initialRelationship));
+  }
+
+  private void assertEntityFoo(@Nonnull Map<String, Object> node, @Nonnull EntityFoo entity) {
+    assertEquals(node.get("urn"), entity.getUrn().toString());
+    assertEquals(node.get("value"), entity.getValue());
+  }
+
+  private void assertEntityBar(@Nonnull Map<String, Object> node, @Nonnull EntityBar entity) {
+    assertEquals(node.get("urn"), entity.getUrn().toString());
+    assertEquals(node.get("value"), entity.getValue());
+  }
+
+  private void assertRelationshipFoo(@Nonnull List<Map<String, Object>> edges, int count) {
+    assertEquals(edges.size(), count);
+    edges.forEach(edge -> assertTrue(edge.isEmpty()));
+  }
+}

--- a/dao-impl/neo4j-dao/build.gradle
+++ b/dao-impl/neo4j-dao/build.gradle
@@ -9,6 +9,7 @@ dependencies {
   compileOnly externalDependency.lombok
   annotationProcessor externalDependency.lombok
 
+  testImplementation testFixtures(project(':dao-api'))
   testCompile project(':testing:test-models')
   testCompile externalDependency.neo4jHarness
 }

--- a/dao-impl/neo4j-dao/src/test/java/com/linkedin/metadata/dao/Neo4jQueryDAOTest.java
+++ b/dao-impl/neo4j-dao/src/test/java/com/linkedin/metadata/dao/Neo4jQueryDAOTest.java
@@ -7,22 +7,12 @@ import com.linkedin.metadata.query.Filter;
 import com.linkedin.metadata.query.RelationshipDirection;
 import com.linkedin.metadata.query.RelationshipFilter;
 import com.linkedin.testing.EntityBar;
-import com.linkedin.testing.EntityBaz;
 import com.linkedin.testing.EntityFoo;
 import com.linkedin.testing.RelationshipBar;
 import com.linkedin.testing.RelationshipFoo;
 import com.linkedin.testing.TestUtils;
 import com.linkedin.testing.urn.BarUrn;
-import com.linkedin.testing.urn.BazUrn;
 import com.linkedin.testing.urn.FooUrn;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import org.javatuples.Triplet;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.GraphDatabase;
 import org.neo4j.driver.Record;
@@ -30,26 +20,44 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static com.linkedin.metadata.dao.Neo4jUtil.*;
+import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
 import static com.linkedin.metadata.dao.utils.QueryUtils.*;
-import static com.linkedin.testing.TestUtils.*;
-import static org.testng.Assert.*;
+import static com.linkedin.metadata.dao.utils.QueryUtils.EMPTY_FILTER;
+import static com.linkedin.testing.TestUtils.makeBarUrn;
+import static com.linkedin.testing.TestUtils.makeFooUrn;
+import static org.testng.Assert.assertEquals;
 
 
-public class Neo4jQueryDAOTest {
+public class Neo4jQueryDAOTest extends BaseQueryDAOTestBase<Neo4jQueryDAO, Neo4jGraphWriterDAO> {
 
   private Neo4jTestServerBuilder _serverBuilder;
-  private Neo4jQueryDAO _dao;
-  private Neo4jGraphWriterDAO _writer;
+  private Driver _driver;
 
+  @Nonnull
+  @Override
+  Neo4jQueryDAO newBaseQueryDao() {
+    return new Neo4jQueryDAO(_driver);
+  }
+
+  @Nonnull
+  @Override
+  Neo4jGraphWriterDAO newBaseGraphWriterDao() {
+    return new Neo4jGraphWriterDAO(_driver, TestUtils.getAllTestEntities());
+  }
+
+  @Override
   @BeforeMethod
   public void init() {
     _serverBuilder = new Neo4jTestServerBuilder();
     _serverBuilder.newServer();
+    _driver = GraphDatabase.driver(_serverBuilder.boltURI());
 
-    final Driver driver = GraphDatabase.driver(_serverBuilder.boltURI());
-    _dao = new Neo4jQueryDAO(driver);
-    _writer = new Neo4jGraphWriterDAO(driver, TestUtils.getAllTestEntities());
+    super.init();
   }
 
   @AfterMethod
@@ -57,423 +65,6 @@ public class Neo4jQueryDAOTest {
     _serverBuilder.shutdown();
   }
 
-  @Test
-  public void testFindEntityByUrn() throws Exception {
-    FooUrn urn = makeFooUrn(1);
-    EntityFoo entity = new EntityFoo().setUrn(urn).setValue("foo");
-
-    _writer.addEntity(entity);
-
-    Filter filter = newFilter("urn", urn.toString());
-    List<EntityFoo> found = _dao.findEntities(EntityFoo.class, filter, -1, -1);
-
-    assertEquals(found.size(), 1);
-    assertEquals(found.get(0), entity);
-  }
-
-  @Test
-  public void testFindEntityByAttribute() throws Exception {
-    FooUrn urn1 = makeFooUrn(1);
-    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo");
-    _writer.addEntity(entity1);
-
-    FooUrn urn2 = makeFooUrn(2);
-    EntityFoo entity2 = new EntityFoo().setUrn(urn2).setValue("foo");
-    _writer.addEntity(entity2);
-
-    // find by removed
-    Filter filter1 = newFilter("value", "foo");
-    List<EntityFoo> found = _dao.findEntities(EntityFoo.class, filter1, -1, -1);
-    assertEquals(found, Arrays.asList(entity1, entity2));
-
-    // find with limit
-    found = _dao.findEntities(EntityFoo.class, filter1, -1, 1);
-    assertEquals(found, Collections.singletonList(entity1));
-
-    // find with offset
-    found = _dao.findEntities(EntityFoo.class, filter1, 1, -1);
-    assertEquals(found, Collections.singletonList(entity2));
-  }
-
-  @Test
-  public void testFindEntityByQuery() throws Exception {
-    FooUrn urn1 = makeFooUrn(1);
-    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo");
-    _writer.addEntity(entity1);
-
-    Statement statement = new Statement("MATCH (n {value:\"foo\"}) RETURN n ORDER BY n.urn", Collections.emptyMap());
-    List<EntityFoo> found = _dao.findEntities(EntityFoo.class, statement);
-    assertEquals(found.size(), 1);
-    assertEquals(found.get(0), entity1);
-
-    FooUrn urn2 = makeFooUrn(2);
-    EntityFoo entity2 = new EntityFoo().setUrn(urn2).setValue("foo");
-    _writer.addEntity(entity2);
-
-    found = _dao.findEntities(EntityFoo.class, statement);
-    assertEquals(found.size(), 2);
-    assertEquals(found.get(0), entity1);
-    assertEquals(found.get(1), entity2);
-  }
-
-  @Test
-  public void testFindEntityWithOneRelationship() throws Exception {
-    // Test interface 1 & 3
-    FooUrn urn1 = makeFooUrn(1);
-    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo1");
-    _writer.addEntity(entity1);
-
-    FooUrn urn2 = makeFooUrn(2);
-    EntityFoo entity2 = new EntityFoo().setUrn(urn2).setValue("foo2");
-    _writer.addEntity(entity2);
-
-    FooUrn urn3 = makeFooUrn(3);
-    EntityFoo entity3 = new EntityFoo().setUrn(urn3).setValue("foo3");
-    _writer.addEntity(entity3);
-
-    BarUrn urn4 = makeBarUrn(4);
-    EntityBar entity4 = new EntityBar().setUrn(urn4).setValue("bar4");
-    _writer.addEntity(entity4);
-
-    BarUrn urn5 = makeBarUrn(5);
-    EntityBar entity5 = new EntityBar().setUrn(urn5).setValue("bar5");
-    _writer.addEntity(entity5);
-
-    // create relationship urn1 -(r:Foo)-> urn2 -(r:Foo)-> urn3 (example use case: ReportTo list)
-    // also relationship urn1 -(r:Foo)-> urn4, and urn1 -(r:Bar)-> urn5
-    RelationshipFoo relationshipFoo1To2 = new RelationshipFoo().setSource(urn1).setDestination(urn2);
-    _writer.addRelationship(relationshipFoo1To2);
-
-    RelationshipFoo relationshipFoo2o3 = new RelationshipFoo().setSource(urn2).setDestination(urn3).setType("apa");
-    _writer.addRelationship(relationshipFoo2o3);
-
-    RelationshipFoo relationshipFoo1o4 = new RelationshipFoo().setSource(urn1).setDestination(urn4);
-    _writer.addRelationship(relationshipFoo1o4);
-
-    RelationshipBar relationshipBar1o5 = new RelationshipBar().setSource(urn1).setDestination(urn5);
-    _writer.addRelationship(relationshipBar1o5);
-
-    // test source filter with urn
-    Filter sourceFilter = newFilter("urn", urn2.toString());
-
-    // use case: the direct reportee to me (urn2)
-    List<RecordTemplate> resultIncoming =
-        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING), 0, 10);
-    assertEquals(resultIncoming.size(), 1);
-    assertEquals(resultIncoming.get(0), entity1);
-
-    // use case: the manager I (urn2) am report to
-    List<RecordTemplate> resultOutgoing =
-        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 0, 10);
-    assertEquals(resultOutgoing.size(), 1);
-    assertEquals(resultOutgoing.get(0), entity3);
-
-    // use case: give me my friends at one degree/hop
-    List<RecordTemplate> resultUndirected =
-        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.UNDIRECTED), 0, 10);
-    assertEquals(resultUndirected.size(), 2);
-    assertEquals(resultUndirected.get(0), entity1);
-    assertEquals(resultUndirected.get(1), entity3);
-
-    // Test: if dest entity type is not specified, from urn1, it will return a mixed collection of entities like urn2 and urn4
-    // urn5 should not be returned because it is based on RelationshipBar.
-    sourceFilter = newFilter("urn", urn1.toString());
-    List<RecordTemplate> resultNullDest =
-        _dao.findEntities(EntityFoo.class, sourceFilter, null, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 0, 10);
-    assertEquals(resultNullDest.size(), 2);
-    assertEquals(resultNullDest.get(0), entity2);
-    assertEquals(resultNullDest.get(1), entity4);
-
-    // Test: source filter on other attributes
-    sourceFilter = newFilter("value", "foo2");
-    List<RecordTemplate> result =
-        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING), 0, 10);
-    assertEquals(result, resultIncoming);
-
-    //Test relationship filters on the attributes
-    Filter filter = newFilter("type", "apa");
-    List<RecordTemplate> resultWithRelationshipFilter =
-        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(filter, RelationshipDirection.OUTGOING), 0, 10);
-    assertEquals(resultWithRelationshipFilter.size(), 1);
-    assertEquals(resultWithRelationshipFilter.get(0), entity3);
-
-    //Test a wrong value for relationship filters
-    Filter relationshipFilterWrongValue = newFilter("type", "wrongValue");
-    List<RecordTemplate> resultWithRelationshipFilter2 =
-        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(relationshipFilterWrongValue, RelationshipDirection.OUTGOING), 0, 10);
-    assertEquals(resultWithRelationshipFilter2.size(), 0);
-  }
-
-  @Test
-  public void testFindEntitiesMultiHops() throws Exception {
-    // Test interface 5
-    FooUrn urn1 = makeFooUrn(1);
-    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo1");
-    _writer.addEntity(entity1);
-
-    FooUrn urn2 = makeFooUrn(2);
-    EntityFoo entity2 = new EntityFoo().setUrn(urn2).setValue("foo2");
-    _writer.addEntity(entity2);
-
-    FooUrn urn3 = makeFooUrn(3);
-    EntityFoo entity3 = new EntityFoo().setUrn(urn3).setValue("foo3");
-    _writer.addEntity(entity3);
-
-    // create relationship urn1 -> urn2 -> urn3 (use case: ReportTo list)
-    RelationshipFoo relationshipFoo1To2 = new RelationshipFoo().setSource(urn1).setDestination(urn2);
-    _writer.addRelationship(relationshipFoo1To2);
-
-    RelationshipFoo relationshipFoo2o3 = new RelationshipFoo().setSource(urn2).setDestination(urn3);
-    _writer.addRelationship(relationshipFoo2o3);
-
-    // From urn1, get result with one hop, such as direct manager
-    Filter sourceFilter = newFilter("urn", urn1.toString());
-    List<RecordTemplate> result =
-        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 1, 1, 0, 10);
-    assertEquals(result.size(), 1);
-    assertEquals(result.get(0), entity2);
-
-    // get result with 2 hops, two managers
-    List<RecordTemplate> result2 =
-        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 1, 2, 0, 10);
-    assertEquals(result2.size(), 2);
-    assertEquals(result2.get(0), entity2);
-    assertEquals(result2.get(1), entity3);
-
-    // get result with >= 3 hops, until end of the chain
-    List<RecordTemplate> result3 =
-        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 1, 3, 0, 10);
-    assertEquals(result3.size(), 2);
-    assertEquals(result3.get(0), entity2);
-    assertEquals(result3.get(1), entity3);
-
-    // test dest filter, filter the list of result and only get urn3 back
-    Filter destFilter = newFilter("urn", urn3.toString());
-    List<RecordTemplate> result4 =
-        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, destFilter, RelationshipFoo.class,
-            createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 1, 3, 0, 10);
-    assertEquals(result4.size(), 1);
-    assertEquals(result4.get(0), entity3);
-
-    // test relationship filter: TODO: for all the interfaces add relationship filter testing
-
-    // corner cases 1: minHops set to 3, get no result because the relationship chain reaches the end
-    List<RecordTemplate> result5 =
-        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 3, 6, 0, 10);
-    assertEquals(result5.size(), 0);
-
-    // corner cases 2: minHops < maxHops, return no result
-    List<RecordTemplate> result6 =
-        _dao.findEntities(EntityFoo.class, sourceFilter, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 6, 0, 0, 10);
-    assertEquals(result6.size(), 0);
-
-    // test the relationship directions
-    // From urn2, get result with one hop, such as direct manager.
-    // NOTE: without direction specified in the matchTemplate, urn1 could end up in the result too
-    Filter sourceFilter2 = newFilter("urn", urn2.toString());
-    List<RecordTemplate> result21 =
-        _dao.findEntities(EntityFoo.class, sourceFilter2, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 1, 1, 0, 10);
-    assertEquals(result21.size(), 1);
-    assertEquals(result21.get(0), entity3);
-
-    // get result with 2 hops, 1 manager
-    List<RecordTemplate> result22 =
-        _dao.findEntities(EntityFoo.class, sourceFilter2, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 1, 2, 0, 10);
-    assertEquals(result22.size(), 1);
-    assertEquals(result22.get(0), entity3);
-
-    // let's see what we get if we use interface 1, it should return urn3 only
-    List<RecordTemplate> resultInterface1 =
-        _dao.findEntities(EntityFoo.class, sourceFilter2, null, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), 0, 10);
-    assertEquals(resultInterface1.size(), 1);
-    assertEquals(resultInterface1.get(0), entity3);
-
-    // test INCOMING direction, use case such as who report to URN3
-    Filter sourceFilter3 = newFilter("urn", urn3.toString());
-    List<RecordTemplate> resultIncoming =
-        _dao.findEntities(EntityFoo.class, sourceFilter3, EntityFoo.class, EMPTY_FILTER, RelationshipFoo.class,
-            createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING), 1, 2, 0, 10);
-    assertEquals(resultIncoming.size(), 2);
-    assertEquals(resultIncoming.get(0), entity2);
-    assertEquals(resultIncoming.get(1), entity1);
-  }
-
-  @Test
-  public void testFindEntitiesViaTraversePathes() throws Exception {
-    // Test interface 4
-    FooUrn urn1 = makeFooUrn(1);
-    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("CorpGroup1");
-    _writer.addEntity(entity1);
-
-    BarUrn urn2 = makeBarUrn(2);
-    EntityBar entity2 = new EntityBar().setUrn(urn2).setValue("CorpUser2");
-    _writer.addEntity(entity2);
-
-    BazUrn urn3 = makeBazUrn(3);
-    EntityBaz entity3 = new EntityBaz().setUrn(urn3).setValue("Dataset3");
-    _writer.addEntity(entity3);
-
-    // create relationship urn1 -> urn2 with RelationshipFoo (ex: CorpGroup1 HasMember CorpUser2)
-    RelationshipFoo relationshipFoo1To2 = new RelationshipFoo().setSource(urn1).setDestination(urn2);
-    _writer.addRelationship(relationshipFoo1To2);
-
-    // create relationship urn2 -> urn3 with RelationshipBar (ex: Dataset3 is OwnedBy CorpUser2)
-    RelationshipBar relationshipFoo2o3 = new RelationshipBar().setSource(urn3).setDestination(urn2);
-    _writer.addRelationship(relationshipFoo2o3);
-
-    // test source filter with urn
-    Filter sourceFilter = newFilter("urn", urn1.toString());
-
-    // use case: return all the datasets owned by corpgroup1
-    List paths = new ArrayList();
-    paths.add(
-        Triplet.with(RelationshipFoo.class, createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING),
-            EntityBar.class));
-    paths.add(
-        Triplet.with(RelationshipBar.class, createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING),
-            EntityBaz.class));
-    List<RecordTemplate> result = _dao.findEntities(EntityFoo.class, sourceFilter, paths, 0, 10);
-    assertEquals(result.size(), 1);
-    assertEquals(result.get(0), entity3);
-
-    // use case: return all the datasets owned by corpgroup1
-    List paths2 = new ArrayList();
-    paths2.add(
-        Triplet.with(RelationshipFoo.class, createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.UNDIRECTED),
-            EntityBar.class));
-    paths2.add(
-        Triplet.with(RelationshipBar.class, createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.UNDIRECTED),
-            EntityBaz.class));
-    List<RecordTemplate> result2 = _dao.findEntities(EntityFoo.class, sourceFilter, paths2, 0, 10);
-    assertEquals(result2, result);
-
-    // add another user & dataset
-    BarUrn urn4 = makeBarUrn(4);
-    EntityBar entity4 = new EntityBar().setUrn(urn4).setValue("CorpUser4");
-    _writer.addEntity(entity4);
-
-    BazUrn urn5 = makeBazUrn(5);
-    EntityBaz entity5 = new EntityBaz().setUrn(urn5).setValue("Dataset5");
-    _writer.addEntity(entity5);
-
-    // create relationship urn4 -> urn5 with RelationshipBar
-    RelationshipBar relationshipFoo4o5 = new RelationshipBar().setSource(urn5).setDestination(urn4);
-    _writer.addRelationship(relationshipFoo4o5);
-
-    // create relationship urn1 -> urn4 with RelationshipFoo
-    RelationshipFoo relationshipFoo1To4 = new RelationshipFoo().setSource(urn1).setDestination(urn4);
-    _writer.addRelationship(relationshipFoo1To4);
-
-    List paths3 = new ArrayList();
-    paths3.add(
-        Triplet.with(RelationshipFoo.class, createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING),
-            EntityBar.class));
-    paths3.add(
-        Triplet.with(RelationshipBar.class, createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING),
-            EntityBaz.class));
-    List<RecordTemplate> result3 = _dao.findEntities(EntityFoo.class, sourceFilter, paths3, 0, 10);
-    assertEquals(result3.size(), 2);
-    assertEquals(result3.get(0), entity5);
-    assertEquals(result3.get(1), entity3);
-
-    // test nulls
-    List paths4 = new ArrayList();
-    paths4.add(Triplet.with(null, null, null));
-    List<RecordTemplate> result4 = _dao.findEntities(EntityFoo.class, sourceFilter, paths4, 0, 10);
-    assertEquals(result4.size(), 2);
-    assertEquals(result4.get(0), entity4);
-    assertEquals(result4.get(1), entity2);
-
-    // test partial nulls with entity
-    List paths5 = new ArrayList();
-    paths5.add(
-        Triplet.with(null, createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.OUTGOING), EntityBar.class));
-    List<RecordTemplate> result5 = _dao.findEntities(EntityFoo.class, sourceFilter, paths5, 0, 10);
-    assertEquals(result5.size(), 2);
-    assertEquals(result5.get(0), entity4);
-    assertEquals(result5.get(1), entity2);
-
-    // test partial nulls with relationship
-    List paths6 = new ArrayList();
-    paths6.add(Triplet.with(null, null, EntityBar.class));
-    List<RecordTemplate> result6 = _dao.findEntities(EntityFoo.class, sourceFilter, paths6, 0, 10);
-    assertEquals(result6.size(), 2);
-    assertEquals(result6.get(0), entity4);
-    assertEquals(result6.get(1), entity2);
-  }
-
-  @Test
-  public void testFindRelationship() throws Exception {
-    FooUrn urn1 = makeFooUrn(1);
-    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo");
-    _writer.addEntity(entity1);
-
-    BarUrn urn2 = makeBarUrn(2);
-    EntityBar entity2 = new EntityBar().setUrn(urn2).setValue("bar");
-    _writer.addEntity(entity2);
-
-    // create relationship urn1 -> urn2
-    RelationshipFoo relationship = new RelationshipFoo().setSource(urn1).setDestination(urn2);
-    _writer.addRelationship(relationship);
-
-    // find by source
-    Filter filter1 = newFilter("urn", urn1.toString());
-    List<RelationshipFoo> found =
-        _dao.findRelationshipsFromSource(null, filter1, RelationshipFoo.class, EMPTY_FILTER, -1, -1);
-    assertEquals(found, Collections.singletonList(relationship));
-
-    // find by destination
-    Filter filter2 = newFilter("urn", urn2.toString());
-    found =
-        _dao.findRelationshipsFromDestination(EntityBar.class, filter2, RelationshipFoo.class, EMPTY_FILTER, -1, -1);
-    assertEquals(found, Collections.singletonList(relationship));
-
-    // find by source and destination
-    found = _dao.findRelationships(null, filter1, null, filter2, RelationshipFoo.class, EMPTY_FILTER, 0, 10);
-    assertEquals(found, Collections.singletonList(relationship));
-  }
-
-  @Test
-  public void testFindRelationshipByQuery() throws Exception {
-    FooUrn urn1 = makeFooUrn(1);
-    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo");
-    _writer.addEntity(entity1);
-
-    BarUrn urn2 = makeBarUrn(2);
-    EntityBar entity2 = new EntityBar().setUrn(urn2).setValue("bar");
-    _writer.addEntity(entity2);
-
-    RelationshipFoo relationship = new RelationshipFoo().setSource(urn1).setDestination(urn2);
-    _writer.addRelationship(relationship);
-
-    // with type
-    Map<String, Object> params = new HashMap<>();
-    params.put("src", urn1.toString());
-    Statement statement1 = new Statement("MATCH (src {urn:$src})-[r]->(dest) RETURN src, r, dest", params);
-    List<RelationshipFoo> found = _dao.findRelationships(RelationshipFoo.class, statement1);
-    assertEquals(found, Collections.singletonList(relationship));
-
-    // without type
-    params.put("dest", urn2.toString());
-    Statement statement2 = new Statement("MATCH (src {urn:$src})-[r]->(dest {urn:$dest}) RETURN src, r, dest", params);
-    List<RecordTemplate> foundNoType = _dao.findMixedTypesRelationships(statement2);
-    assertEquals(foundNoType, Collections.singletonList(relationship));
-  }
 
   @Test
   public void testFindNodesInPath() throws Exception {
@@ -510,7 +101,7 @@ public class Neo4jQueryDAOTest {
 
     // Get reports roll-up - 2 levels
     Filter sourceFilter = newFilter("urn", urn1.toString());
-    RelationshipFilter relationshipFilter = createRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING);
+    RelationshipFilter relationshipFilter = newRelationshipFilter(EMPTY_FILTER, RelationshipDirection.INCOMING);
     List<List<RecordTemplate>> paths = _dao.findPaths(EntityFoo.class, sourceFilter, null,
         EMPTY_FILTER, RelationshipFoo.class, relationshipFilter, 1, 2, -1, -1);
     assertEquals(paths.size(), 5);

--- a/dao-impl/neo4j-dao/src/test/java/com/linkedin/metadata/dao/internal/Neo4jGraphWriterDAOTest.java
+++ b/dao-impl/neo4j-dao/src/test/java/com/linkedin/metadata/dao/internal/Neo4jGraphWriterDAOTest.java
@@ -1,20 +1,10 @@
 package com.linkedin.metadata.dao.internal;
 
 import com.linkedin.common.urn.Urn;
-import com.linkedin.metadata.dao.BaseQueryDAO;
+import com.linkedin.data.template.RecordTemplate;
 import com.linkedin.metadata.dao.Neo4jQueryDAO;
 import com.linkedin.metadata.dao.Neo4jTestServerBuilder;
-import com.linkedin.metadata.query.Criterion;
-import com.linkedin.metadata.query.CriterionArray;
-import com.linkedin.metadata.query.Filter;
-import com.linkedin.testing.RelationshipFoo;
-import com.linkedin.testing.EntityFoo;
-import com.linkedin.testing.EntityBar;
 import com.linkedin.testing.TestUtils;
-import com.linkedin.testing.urn.BarUrn;
-import com.linkedin.testing.urn.FooUrn;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -25,18 +15,15 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static com.linkedin.metadata.dao.Neo4jUtil.*;
-import static com.linkedin.metadata.dao.internal.BaseGraphWriterDAO.RemovalOption.*;
-import static com.linkedin.testing.TestUtils.*;
 import static org.testng.Assert.*;
 
 
-public class Neo4jGraphWriterDAOTest {
+public class Neo4jGraphWriterDAOTest extends
+        BaseGraphWriterDAOTestBase<Neo4jGraphWriterDAO, Neo4jQueryDAO> {
 
   private Neo4jTestServerBuilder _serverBuilder;
-  private Neo4jGraphWriterDAO _dao;
+  private Driver _driver;
   private Neo4jTestHelper _helper;
-  private BaseQueryDAO _queryDao;
   private TestMetricListener _testMetricListener;
 
   private static class TestMetricListener implements Neo4jGraphWriterDAO.MetricListener {
@@ -74,16 +61,54 @@ public class Neo4jGraphWriterDAOTest {
     }
   }
 
+  @Nonnull
+  @Override
+  Neo4jGraphWriterDAO newBaseGraphWriterDao() {
+    Neo4jGraphWriterDAO dao = new Neo4jGraphWriterDAO(_driver, TestUtils.getAllTestEntities());
+    dao.addMetricListener(_testMetricListener);
+    return dao;
+  }
+
+  @Nonnull
+  @Override
+  Neo4jQueryDAO newBaseQueryDao() {
+    return new Neo4jQueryDAO(_driver);
+  }
+
+  @Nonnull
+  @Override
+  public Optional<Map<String, Object>> getNode(@Nonnull Urn urn) {
+    return _helper.getNode(urn);
+  }
+
+  @Nonnull
+  @Override
+  public List<Map<String, Object>> getAllNodes(@Nonnull Urn urn) {
+    return _helper.getAllNodes(urn);
+  }
+
+  @Nonnull
+  @Override
+  public List<Map<String, Object>> getEdges(@Nonnull RecordTemplate relationship) {
+    return _helper.getEdges(relationship);
+  }
+
+  @Nonnull
+  @Override
+  public List<Map<String, Object>> getEdgesFromSource(@Nonnull Urn sourceUrn, @Nonnull Class<? extends RecordTemplate> relationshipClass) {
+    return _helper.getEdgesFromSource(sourceUrn, relationshipClass);
+  }
+
+  @Override
   @BeforeMethod
   public void init() {
     _serverBuilder = new Neo4jTestServerBuilder();
     _serverBuilder.newServer();
     _testMetricListener = new TestMetricListener();
-    final Driver driver = GraphDatabase.driver(_serverBuilder.boltURI());
-    _dao = new Neo4jGraphWriterDAO(driver, TestUtils.getAllTestEntities());
-    _helper = new Neo4jTestHelper(driver, TestUtils.getAllTestEntities());
-    _queryDao = new Neo4jQueryDAO(driver);
-    _dao.addMetricListener(_testMetricListener);
+    _driver = GraphDatabase.driver(_serverBuilder.boltURI());
+    _helper = new Neo4jTestHelper(_driver, TestUtils.getAllTestEntities());
+
+    super.init();
   }
 
   @AfterMethod
@@ -92,321 +117,54 @@ public class Neo4jGraphWriterDAOTest {
   }
 
   @Test
-  public void testAddRemoveEntity() throws Exception {
-    FooUrn urn = makeFooUrn(1);
-    EntityFoo entity = new EntityFoo().setUrn(urn).setValue("foo");
-
-    _dao.addEntity(entity);
-    Optional<Map<String, Object>> node = _helper.getNode(urn);
-    assertEntityFoo(node.get(), entity);
+  @Override
+  public void testAddEntity() throws Exception {
+    super.testAddEntity();
     assertEquals(_testMetricListener.entitiesAdded, 1);
     assertEquals(_testMetricListener.entityAddedEvents, 1);
+  }
 
-    _dao.removeEntity(urn);
-    node = _helper.getNode(urn);
-    assertFalse(node.isPresent());
+  @Test
+  @Override
+  public void testRemoveEntity() throws Exception {
+    super.testRemoveEntity();
     assertEquals(_testMetricListener.entitiesRemoved, 1);
     assertEquals(_testMetricListener.entityRemovedEvents, 1);
   }
 
   @Test
-  public void testPartialUpdateEntity() throws Exception {
-    FooUrn urn = makeFooUrn(1);
-    EntityFoo entity = new EntityFoo().setUrn(urn);
-
-    _dao.addEntity(entity);
-    Optional<Map<String, Object>> node = _helper.getNode(urn);
-    assertEntityFoo(node.get(), entity);
-
-    // add value for optional field
-    EntityFoo entity2 = new EntityFoo().setUrn(urn).setValue("IamTheSameEntity");
-    _dao.addEntity(entity2);
-    node = _helper.getNode(urn);
-    assertEquals(_helper.getAllNodes(urn).size(), 1);
-    assertEntityFoo(node.get(), entity2);
-
-    // change value for optional field
-    EntityFoo entity3 = new EntityFoo().setUrn(urn).setValue("ChangeValue");
-    _dao.addEntity(entity3);
-    node = _helper.getNode(urn);
-    assertEquals(_helper.getAllNodes(urn).size(), 1);
-    assertEntityFoo(node.get(), entity3);
+  @Override
+  public void testAddEntities() throws Exception {
+    super.testAddEntities();
+    assertEquals(_testMetricListener.entitiesAdded, 3);
+    assertEquals(_testMetricListener.entityAddedEvents, 1);
   }
 
   @Test
-  public void testAddRemoveEntities() throws Exception {
-    EntityFoo entity1 = new EntityFoo().setUrn(makeFooUrn(1)).setValue("foo");
-    EntityFoo entity2 = new EntityFoo().setUrn(makeFooUrn(2)).setValue("bar");
-    EntityFoo entity3 = new EntityFoo().setUrn(makeFooUrn(3)).setValue("baz");
-    List<EntityFoo> entities = Arrays.asList(entity1, entity2, entity3);
-
-    _dao.addEntities(entities);
-    assertEntityFoo(_helper.getNode(entity1.getUrn()).get(), entity1);
-    assertEntityFoo(_helper.getNode(entity2.getUrn()).get(), entity2);
-    assertEntityFoo(_helper.getNode(entity3.getUrn()).get(), entity3);
-    assertEquals(_testMetricListener.entitiesAdded, 3);
-    assertEquals(_testMetricListener.entityAddedEvents, 1);
-
-    _dao.removeEntities(Arrays.asList(entity1.getUrn(), entity3.getUrn()));
-    assertFalse(_helper.getNode(entity1.getUrn()).isPresent());
-    assertTrue(_helper.getNode(entity2.getUrn()).isPresent());
-    assertFalse(_helper.getNode(entity3.getUrn()).isPresent());
+  @Override
+  public void testRemoveEntities() throws Exception {
+    super.testRemoveEntities();
     assertEquals(_testMetricListener.entitiesRemoved, 2);
     assertEquals(_testMetricListener.entityRemovedEvents, 1);
   }
 
   @Test
+  @Override
   public void testAddRelationshipNodeNonExist() throws Exception {
-    FooUrn urn1 = makeFooUrn(1);
-    BarUrn urn2 = makeBarUrn(2);
-    RelationshipFoo relationship = new RelationshipFoo().setSource(urn1).setDestination(urn2);
-
-    _dao.addRelationship(relationship, REMOVE_NONE);
-
-    assertRelationshipFoo(_helper.getEdges(relationship), 1);
-    assertEntityFoo(_helper.getNode(urn1).get(), new EntityFoo().setUrn(urn1));
-    assertEntityBar(_helper.getNode(urn2).get(), new EntityBar().setUrn(urn2));
+    super.testAddRelationshipNodeNonExist();
     assertEquals(_testMetricListener.relationshipsAdded, 1);
     assertEquals(_testMetricListener.relationshipAddedEvents, 1);
   }
 
   @Test
-  public void testPartialUpdateEntityCreatedByRelationship() throws Exception {
-    FooUrn urn1 = makeFooUrn(1);
-    FooUrn urn2 = makeFooUrn(2);
-    RelationshipFoo relationship = new RelationshipFoo().setSource(urn1).setDestination(urn2);
-
-    _dao.addRelationship(relationship, REMOVE_NONE);
-
-    // Check if adding an entity with same urn and with label creates a new node
-    _dao.addEntity(new EntityFoo().setUrn(urn1));
-    assertEquals(_helper.getAllNodes(urn1).size(), 1);
-  }
-
-  @Test
+  @Override
   public void testAddRemoveRelationships() throws Exception {
-    // Add entity1
-    FooUrn urn1 = makeFooUrn(1);
-    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo");
-    _dao.addEntity(entity1);
-    assertEntityFoo(_helper.getNode(urn1).get(), entity1);
-
-    // Add entity2
-    BarUrn urn2 = makeBarUrn(2);
-    EntityBar entity2 = new EntityBar().setUrn(urn2).setValue("bar");
-    _dao.addEntity(entity2);
-    assertEntityBar(_helper.getNode(urn2).get(), entity2);
-
-    // add relationship1 (urn1 -> urn2)
-    RelationshipFoo relationship1 = new RelationshipFoo().setSource(urn1).setDestination(urn2);
-    _dao.addRelationship(relationship1, REMOVE_NONE);
-    assertRelationshipFoo(_helper.getEdges(relationship1), 1);
-
-    // add relationship1 again
-    _dao.addRelationship(relationship1);
-    assertRelationshipFoo(_helper.getEdges(relationship1), 1);
-
-    // add relationship2 (urn1 -> urn3)
-    Urn urn3 = makeUrn(3);
-    RelationshipFoo relationship2 = new RelationshipFoo().setSource(urn1).setDestination(urn3);
-    _dao.addRelationship(relationship2);
-    assertRelationshipFoo(_helper.getEdgesFromSource(urn1, RelationshipFoo.class), 2);
-
-    // remove relationship1
-    _dao.removeRelationship(relationship1);
-    assertRelationshipFoo(_helper.getEdges(relationship1), 0);
-
-    // remove relationship1 & relationship2
-    _dao.removeRelationships(Arrays.asList(relationship1, relationship2));
-    assertRelationshipFoo(_helper.getEdgesFromSource(urn1, RelationshipFoo.class), 0);
-
+    super.testAddRemoveRelationships();
 
     assertEquals(_testMetricListener.relationshipsAdded, 3);
     assertEquals(_testMetricListener.relationshipAddedEvents, 3);
 
     assertEquals(_testMetricListener.relationshipsRemoved, 3);
     assertEquals(_testMetricListener.relationshipRemovedEvents, 2);
-  }
-
-  @Test
-  public void testAddRelationshipRemoveAll() throws Exception {
-    // Add entity1
-    FooUrn urn1 = makeFooUrn(1);
-    EntityFoo entity1 = new EntityFoo().setUrn(urn1).setValue("foo");
-    _dao.addEntity(entity1);
-    assertEntityFoo(_helper.getNode(urn1).get(), entity1);
-
-    // Add entity2
-    BarUrn urn2 = makeBarUrn(2);
-    EntityBar entity2 = new EntityBar().setUrn(urn2).setValue("bar");
-    _dao.addEntity(entity2);
-    assertEntityBar(_helper.getNode(urn2).get(), entity2);
-
-    // add relationship1 (urn1 -> urn2)
-    RelationshipFoo relationship1 = new RelationshipFoo().setSource(urn1).setDestination(urn2);
-    _dao.addRelationship(relationship1, REMOVE_NONE);
-    assertRelationshipFoo(_helper.getEdges(relationship1), 1);
-
-    // add relationship2 (urn1 -> urn3), removeAll from source
-    Urn urn3 = makeUrn(3);
-    RelationshipFoo relationship2 = new RelationshipFoo().setSource(urn1).setDestination(urn3);
-    _dao.addRelationship(relationship2, REMOVE_ALL_EDGES_FROM_SOURCE);
-    assertRelationshipFoo(_helper.getEdgesFromSource(urn1, RelationshipFoo.class), 1);
-
-    // add relationship3 (urn4 -> urn3), removeAll from destination
-    Urn urn4 = makeUrn(4);
-    RelationshipFoo relationship3 = new RelationshipFoo().setSource(urn4).setDestination(urn3);
-    _dao.addRelationship(relationship3, REMOVE_ALL_EDGES_TO_DESTINATION);
-    assertRelationshipFoo(_helper.getEdgesFromSource(urn1, RelationshipFoo.class), 0);
-    assertRelationshipFoo(_helper.getEdgesFromSource(urn4, RelationshipFoo.class), 1);
-
-    // add relationship3 again without removal
-    _dao.addRelationship(relationship3);
-    assertRelationshipFoo(_helper.getEdgesFromSource(urn4, RelationshipFoo.class), 1);
-
-    // add relationship3 again, removeAll from source & destination
-    _dao.addRelationship(relationship3, REMOVE_ALL_EDGES_FROM_SOURCE_TO_DESTINATION);
-    assertRelationshipFoo(_helper.getEdgesFromSource(urn1, RelationshipFoo.class), 0);
-    assertRelationshipFoo(_helper.getEdgesFromSource(urn4, RelationshipFoo.class), 1);
-  }
-
-  @Test
-  public void upsertNodeAddNewProperty() throws Exception {
-    // given
-    final FooUrn urn = makeFooUrn(1);
-    final EntityFoo initialEntity = new EntityFoo().setUrn(urn);
-    final EntityFoo updatedEntity = new EntityFoo().setUrn(urn).setValue("updated");
-
-    // when
-    _dao.addEntity(initialEntity);
-    _dao.addEntity(updatedEntity);
-
-    // then
-    assertEntityFoo(_helper.getNode(urn).get(), updatedEntity);
-  }
-
-  @Test
-  public void upsertEdgeAddNewProperty() throws Exception {
-    // given
-    final EntityFoo foo = new EntityFoo().setUrn(makeFooUrn(1));
-    final EntityBar bar = new EntityBar().setUrn(makeBarUrn(2)).setValue("bar");
-    _dao.addEntity(foo);
-    _dao.addEntity(bar);
-
-    final RelationshipFoo initialRelationship =
-        new RelationshipFoo().setSource(foo.getUrn()).setDestination(bar.getUrn());
-    final RelationshipFoo updatedRelationship =
-        new RelationshipFoo().setSource(foo.getUrn()).setDestination(bar.getUrn()).setType("test");
-    _dao.addRelationship(initialRelationship);
-
-    // when
-    _dao.addRelationship(updatedRelationship);
-
-    // then
-    assertEquals(_queryDao.findRelationships(EntityFoo.class,
-        new Filter().setCriteria(new CriterionArray(new Criterion().setField("urn").setValue(foo.getUrn().toString()))),
-        EntityBar.class,
-        new Filter().setCriteria(new CriterionArray(new Criterion().setField("urn").setValue(bar.getUrn().toString()))),
-        RelationshipFoo.class, new Filter().setCriteria(new CriterionArray()), 0, 10),
-        Collections.singletonList(updatedRelationship));
-  }
-
-  @Test
-  public void upsertNodeChangeProperty() throws Exception {
-    // given
-    final FooUrn urn = makeFooUrn(1);
-    final EntityFoo initialEntity = new EntityFoo().setUrn(urn).setValue("before");
-    final EntityFoo updatedEntity = new EntityFoo().setUrn(urn).setValue("after");
-    _dao.addEntity(initialEntity);
-
-    // when
-    _dao.addEntity(updatedEntity);
-
-    // then
-    assertEntityFoo(_helper.getNode(urn).get(), updatedEntity);
-  }
-
-  @Test
-  public void upsertEdgeChangeProperty() throws Exception {
-    // given
-    final EntityFoo foo = new EntityFoo().setUrn(makeFooUrn(1));
-    final EntityBar bar = new EntityBar().setUrn(makeBarUrn(2)).setValue("bar");
-    _dao.addEntity(foo);
-    _dao.addEntity(bar);
-
-    final RelationshipFoo initialRelationship =
-        new RelationshipFoo().setSource(foo.getUrn()).setDestination(bar.getUrn()).setType("before");
-    final RelationshipFoo updatedRelationship =
-        new RelationshipFoo().setSource(foo.getUrn()).setDestination(bar.getUrn()).setType("after");
-    _dao.addRelationship(initialRelationship);
-
-    // when
-    _dao.addRelationship(updatedRelationship);
-
-    // then
-    assertEquals(_queryDao.findRelationships(EntityFoo.class,
-        new Filter().setCriteria(new CriterionArray(new Criterion().setField("urn").setValue(foo.getUrn().toString()))),
-        EntityBar.class,
-        new Filter().setCriteria(new CriterionArray(new Criterion().setField("urn").setValue(bar.getUrn().toString()))),
-        RelationshipFoo.class, new Filter().setCriteria(new CriterionArray()), 0, 10),
-        Collections.singletonList(updatedRelationship));
-  }
-
-  @Test
-  public void upsertNodeRemovedProperty() throws Exception {
-    // given
-    final FooUrn urn = makeFooUrn(1);
-    final EntityFoo initialEntity = new EntityFoo().setUrn(urn).setValue("before");
-    final EntityFoo updatedEntity = new EntityFoo().setUrn(urn);
-    _dao.addEntity(initialEntity);
-
-    // when
-    _dao.addEntity(updatedEntity);
-
-    // then
-    // Upsert won't ever delete properties.
-    assertEntityFoo(_helper.getNode(urn).get(), initialEntity);
-  }
-
-  @Test
-  public void upsertEdgeRemoveProperty() throws Exception {
-    // given
-    final EntityFoo foo = new EntityFoo().setUrn(makeFooUrn(1));
-    final EntityBar bar = new EntityBar().setUrn(makeBarUrn(2)).setValue("bar");
-    _dao.addEntity(foo);
-    _dao.addEntity(bar);
-
-    final RelationshipFoo initialRelationship =
-        new RelationshipFoo().setSource(foo.getUrn()).setDestination(bar.getUrn()).setType("before");
-    final RelationshipFoo updatedRelationship =
-        new RelationshipFoo().setSource(foo.getUrn()).setDestination(bar.getUrn());
-    _dao.addRelationship(initialRelationship);
-
-    // when
-    _dao.addRelationship(updatedRelationship);
-
-    // then
-    assertEquals(_queryDao.findRelationships(EntityFoo.class,
-        new Filter().setCriteria(new CriterionArray(new Criterion().setField("urn").setValue(foo.getUrn().toString()))),
-        EntityBar.class,
-        new Filter().setCriteria(new CriterionArray(new Criterion().setField("urn").setValue(bar.getUrn().toString()))),
-        RelationshipFoo.class, new Filter().setCriteria(new CriterionArray()), 0, 10),
-        // Upsert won't ever delete properties.
-        Collections.singletonList(initialRelationship));
-  }
-
-  private void assertEntityFoo(@Nonnull Map<String, Object> node, @Nonnull EntityFoo entity) {
-    assertEquals(node.get("urn"), entity.getUrn().toString());
-    assertEquals(node.get("value"), entity.getValue());
-  }
-
-  private void assertEntityBar(@Nonnull Map<String, Object> node, @Nonnull EntityBar entity) {
-    assertEquals(node.get("urn"), entity.getUrn().toString());
-    assertEquals(node.get("value"), entity.getValue());
-  }
-
-  private void assertRelationshipFoo(@Nonnull List<Map<String, Object>> edges, int count) {
-    assertEquals(edges.size(), count);
-    edges.forEach(edge -> assertTrue(edge.isEmpty()));
   }
 }


### PR DESCRIPTION
Refactoring of `Neo4jGraphWriterDAOTest` and `Neo4jQueryDAOTest` similar to #2944. This makes these tests reusable for other implementations of `BaseGraphWriterDAO` and `BaseQueryDAO`.